### PR TITLE
Hilfeseiten

### DIFF
--- a/themes/swissbibmulti/templates/HelpPage/de/faq.phtml
+++ b/themes/swissbibmulti/templates/HelpPage/de/faq.phtml
@@ -7,20 +7,13 @@
   <li>
   <strong>Warum funktioniert der Link zum Volltext bei E-Books und Artikeln nicht immer?</strong>
   <br/>Der Zugang zum Volltext funktioniert oft nur aus dem Netz der Universität, die den Inhalt lizenziert hat. Melden Sie sich deshalb über VPN an, wenn Sie sich nicht auf dem Campus befinden.</li>
-       <!--
-         <li><strong>Was ist Sortieren nach Relevanz?</strong>
-        <br/>Treffer in Haupttitel, Verfasser und Thema kommen vor solchen in anderen Feldern.</li>
-        -->
-   </ul>
+          </ul>
 
 <h2>Bestellen</h2>
 <ul class="list">
-           <li><strong>Ich habe ein neues Konto angelegt, kann aber trotzdem nicht bestellen.</strong>
-            <br/>Sie müssen zuerst von einer Bibliothek freigeschaltet werden, melden Sie sich bei einer der <a href="http://www.ub.unibas.ch/ids-basel-bern/ausleihbibliotheken" target="_blank">Ausleihbibliotheken</a>.</li>
-        <li><strong>Können Sie mir Werk xy senden?</strong>
+     <li><strong>Können Sie mir Werk xy senden?</strong>
             <br/>Wählen Sie die Bibliothek, bei der Sie bestellen möchten. Klicken Sie auf <i>Bestellen</i>. Wenn Postversand an Ihre Adresse möglich ist, können Sie die Option bei <i>Abholort/Lieferadresse</i> wählen.</li>
        </ul>
-
 
        <h2>My swissbib</h2>
 <ul class="list">
@@ -36,10 +29,3 @@
       <br/>Link aus dem Katalog: Klick auf das <img src="<?= $this->basePath('themes/swissbibmulti/css/img/icon_info.gif') ?>"                               alt="Bibliotheksinformation"> neben der Signatur.</li>
       <li>Kontakt swissbib Basel Bern: E-Mail an <a href="mailto:swissbib-baselbern@unibas.ch">swissbib-baselbern@unibas.ch</a> oder Kommentar im <a href="http://swissbib-baselbern.blogspot.ch" target="_blank">Blog</a>.</li>
 </ul> 
-
-       
-<!--       
-<div class="example">Ist Ihre Frage nicht dabei? Melden Sie sich via <a href="http://swissbib-baselbern.blogspot.com" target="_blank">Blog</a>,
-    <a href="mailto:swissbib-baselbern@unibas.ch">Email</a> oder <a href="https://twitter.com/swissbibBB">@swissbibBB</a>.
-</div>
--->

--- a/themes/swissbibmulti/templates/HelpPage/en/faq.phtml
+++ b/themes/swissbibmulti/templates/HelpPage/en/faq.phtml
@@ -4,23 +4,15 @@
     <li>
        <li><strong>Can I search within a certain library?</strong>
          <br/>Either mark the library as favorite and filter your search results with <i>Refine search - Favorites</i> or use <i>Advanced search - Refine search - Library</i>.</li>   
-         
-         
-<li><strong>Why can't I always see the full text of e-books, articles, etc.?</strong>
-<br/>Access to full text is often only possible from the university having licenced the content. Log in via VPN if you're not on campus.</li>
-      <!--   <li><strong>What is Sort by Relevance?</strong>
-        <br/>Hits in main title, author name and subjects rank higher than hits in other fields.</li>
-      --> 
- </ul>
+  <li><strong>Why can't I always see the full text of e-books, articles, etc.?</strong>
+  <br/>Access to full text is often only possible from the university having licenced the content. Log in via VPN if you're not on campus.</li>
+     </ul>
 
 <h2>Order</h2>
 <ul class="list">
         <li><strong>Could you send me the following book: ...?</strong>
             <br/>Choose the library you'd like to order from. Click on <i>Order</i>. If getting the book sent to your home address is possible you see it as one of the options under <i>Pickup/delivery location</i>. 
                    </li>
-                   
-           <li><strong>I just created a new account but can't order anyway.</strong>
-            <br/>Ask one of these libraries to activate your account: <a href="http://www.ub.unibas.ch/ids-basel-bern/ausleihbibliotheken" target="_blank">Ausleihbibliotheken</a>.</li>        
                           </ul>
 
    <h2>My swissbib</h2>
@@ -38,9 +30,3 @@
                                alt="Library Info"> next to the call number.</li>
   <li>To contact swissbib Basel Bern write to <a href="mailto:swissbib-baselbern@unibas.ch">swissbib-baselbern@unibas.ch</a> or post a comment in our <a href="http://swissbib-baselbern.blogspot.ch" target="_blank">blog</a>.</li>
                                </ul>
-                               
-<!--       
-<div class="example">Is your question not covered? Ask us in the <a
-        href="http://swissbib-baselbern.blogspot.com" target="_blank">blog</a>, by <a href="mailto:swissbib-baselbern@unibas.ch">email</a> or <a href="https://twitter.com/swissbibBB" target="_blank">@swissbibBB</a>.
-</div>
--->

--- a/themes/swissbibmulti/templates/HelpPage/fr/faq.phtml
+++ b/themes/swissbibmulti/templates/HelpPage/fr/faq.phtml
@@ -3,24 +3,13 @@
 <ul class="list">
   <li><strong>Est-il possible d'effectuer une recherche dans le fonds d'une bibliothèque définie?</strong>
          <br/>Soit en sélectionant la bibliothèque en tant que favorit et en utilisant dans la liste de résultats <i>Affiner la recherche - Favoris</i> ou en utilisant <i>Recherche avancée - Affiner la recherche - Bibliothèque</i>.</li>   
-  
-  
 <li><strong>Porquoi l'accès au texte intégral ne fonctionne pas toujours?</strong>
 <br/>Pour l'accès au texte intégral vous devez vous trouver sur le campus de l'université qui a licencié le titre ou vous indetifier par VPN.</li>
-  
-  <!--
-  <li><strong>Trier par pertinance?</strong>
-        <br/>Les concordances dans le titre, l'auteur et le thème sont affichées en prioritée. 
-    </li>
-    -->
 </ul>
 
 
 <h2>Commander</h2>
 <ul class="list">
-         <li><strong>I just created a new account but can't order anyway.</strong>
-            <br/>Ask one of these libraries to activate your account: <a href="http://www.ub.unibas.ch/ids-basel-bern/ausleihbibliotheken" target="_blank">Ausleihbibliotheken</a>.</li>        
-
     <li><strong>Pouvez vous m'envoyer l'ouvrage xy?</strong>
         <br/>Sélectionnez la bibliothèque de votre choix. Cliquez sur <i>Commander</i>. Si
         l'envoi postal à votre adresse peut se faire, vous pouvez choisir cette option sous <i>Lieu de
@@ -44,10 +33,3 @@
   <li>Contacter swissbib Basel Bern: e-mail à <a
         href="mailto:swissbib-baselbern@unibas.ch">swissbib-baselbern@unibas.ch</a> ou commentaire dans le <a href="http://swissbib-baselbern.blogspot.ch" target="_blank">blog</a>.</li>
 </ul>         
-       
-<!--       
-<div class="example">Vous ne trouvez pas la réponse à votre question? Contactez-nous via <a
-        href="http://swissbib-baselbern.blogspot.com" target="_blank">blog</a>, <a
-        href="mailto:swissbib-baselbern@unibas.ch">mail</a> ou <a href="https://twitter.com/swissbibBB"                                                                  target="_blank">@swissbibBB</a>.
-</div>
--->

--- a/themes/swissbibmulti/templates/HelpPage/it/faq.phtml
+++ b/themes/swissbibmulti/templates/HelpPage/it/faq.phtml
@@ -3,20 +3,12 @@
 <ul class="list">
          <li><strong>Posso limitare la mia ricerca a una determinata biblioteca?</strong>
          <br/>Ci sono varie possibilità. Nella lista dei risultati, puoi usare il filtro <i>Affinare la ricerca - Biblioteca</i> oppure <i>Affinare la ricerca - Preferite</i> (se hai già predefinito delle biblioteche preferite).<br/>Nella ricerca avanzata puoi selezionare una biblioteca sotto <i>Affinare la ricerca</i>.</li>  
-         
         <li><strong>Perché qualche volta non posso accedere al testo integrale?</strong>
     <br/>L'accesso diretto al testo integrale spesso funziona solo all'interno della rete di un'università che possieda una sottoscrizione per i contenuti. Effettua il login tramite VPN se non ti trovi in una sede universitaria.</li> 
-      <!--   
-     <li><strong>Che cosa significa Ordina per Rilevanza?</strong>
-        <br/>I risultati in cui i termini della tua ricerca appaiono nei campi del titolo, dell'autore o del soggetto hanno priorità su quelli in cui i termini appaiono in altri campi bibliografici.</li>
-        -->
-     </ul>
+         </ul>
            
 <h2>Ordinare</h2>
 <ul class="list">
-          <li><strong>I just created a new account but can't order anyway.</strong>
-            <br/>Ask one of these libraries to activate your account: <a href="http://www.ub.unibas.ch/ids-basel-bern/ausleihbibliotheken" target="_blank">Ausleihbibliotheken</a>.</li>        
-
         <li><strong>Potete inviarmi il documento xy?</strong>
             <br/>Scegli la biblioteca dalla quale desideri ordinare il documento. Clicca su <i>Ordinare</i>. Se è possibile la spedizione postale al tuo recapito privato, la troverai quale opzione sotto <i>Punto di ritiro/invio</i>. 
                    </li>
@@ -28,7 +20,6 @@
             <br/>Effettua il login, poi clicca su <i>Conto: il tuo nome</i> in alto a destra.</li>
        </ul>       
        
-       
 <h2>Non trovi risposta alla tua domanda?</h2>       
 <ul class="list">
 <li>Per domande concernenti il tuo conto ti preghiamo di contattare la <a href="http://www.ub.unibas.ch/ids-basel-bern/ausleihbibliotheken/" target="_blank">tua biblioteca</a>.</li>
@@ -36,9 +27,3 @@
     catalogo: clicca sull'icona <img src="<?= $this->basePath('themes/swissbibmulti/css/img/icon_info.gif') ?>"
                                      alt="Info biblioteca"> accanto alla segnatura.</li>
 <li>Contatto swissbib Basel Bern: inviaci una e-mail a <a href="mailto:swissbib-baselbern@unibas.ch">swissbib-baselbern@unibas.ch</a> oppure scrivi un commento sul nostro <a href="http://swissbib-baselbern.blogspot.ch" target="_blank">blog</a>.</li> </ul>
-
-<!--                     
-<div class="example">Non trovi risposta alla tua domanda? Scrivicela sul <a
-        href="http://swissbib-baselbern.blogspot.com" target="_blank">blog</a>, per <a href="mailto:swissbib-baselbern@unibas.ch">e-mail</a> o tramite <a href="https://twitter.com/swissbibBB" target="_blank">@swissbibBB</a>.
-</div>
--->


### PR DESCRIPTION
Info "Neues Konto kann nicht bestellen" wird über die Fehlermeldung aufgefangen.
